### PR TITLE
Added Develocity configuration and enabled remote build cache.

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -26,6 +26,8 @@ jobs:
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
       - name: Run Checkstyle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleTestFixtures
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   Javadoc:
     runs-on: ubuntu-latest
@@ -34,6 +36,8 @@ jobs:
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
       - name: Run Javadoc
         run: ./gradlew javadoc
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   Verify-Identityhub-Launcher:
     runs-on: ubuntu-latest
@@ -43,6 +47,8 @@ jobs:
 
       - name: 'Build launcher'
         run: ./gradlew :launcher:identityhub:shadowJar
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Build Docker image'
         run: docker build -t identityhub ./launcher/identityhub
@@ -73,6 +79,8 @@ jobs:
 
       - name: 'Build launcher'
         run: ./gradlew :launcher:issuer-service:shadowJar
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Build Docker image'
         run: docker build -t issuer-service ./launcher/issuer-service
@@ -109,6 +117,7 @@ jobs:
         timeout-minutes: 10
         env:
           INTEGRATION_TEST: true
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   Integration-Tests:
     runs-on: ubuntu-latest
@@ -118,6 +127,8 @@ jobs:
 
       - name: Component Tests
         run: ./gradlew compileJava compileTestJava test -DincludeTags="ComponentTest,ApiTest,EndToEndTest"
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   Postgresql-Integration-Tests:
     runs-on: ubuntu-latest
@@ -127,6 +138,8 @@ jobs:
 
       - name: Postgresql Tests
         run: ./gradlew compileJava compileTestJava test -DincludeTags="PostgresqlIntegrationTest"
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   Verify-OpenApi:
     if: github.event_name == 'pull_request'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,5 @@ version=0.12.0-SNAPSHOT
 # information required for publishing artifacts:
 edcScmConnection=scm:git:git@github.com:eclipse-edc/IdentityHub.git
 edcScmUrl=https://github.com/eclipse-edc/IdentityHub.git
+
+org.gradle.caching=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,11 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("com.gradle.develocity") version "3.19.2"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.1"
+}
+
 dependencyResolutionManagement {
 
     repositories {
@@ -136,3 +141,30 @@ include(":dist:bom:identityhub-feature-sql-bom")
 include(":dist:bom:issuerservice-base-bom")
 include(":dist:bom:issuerservice-bom")
 include(":dist:bom:issuerservice-feature-sql-bom")
+
+// Develocity
+val isCI = System.getenv("CI") != null // adjust to your CI provider
+
+develocity {
+    server = "https://develocity-staging.eclipse.org"
+    projectId = "technology.edc"
+    buildScan {
+        uploadInBackground = !isCI
+        publishing.onlyIf { it.isAuthenticated }
+        obfuscation {
+            ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
+        }
+    }
+}
+
+buildCache {
+    local {
+        isEnabled = true
+    }
+
+    remote(develocity.buildCache) {
+        isEnabled = true
+        isPush = isCI
+    }
+}
+


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as explained in the issue https://github.com/eclipse-edc/IdentityHub/issues/628.

## Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Setting the access key env var was added in relevant CI pipelines, however, the secret will need to be set by Eclipse infra - you can initiate that by opening a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket.

The build scans of the Eclipse EDC Identity Hub project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse EDC Identity Hub project and all other Eclipse projects.

On this Develocity instance, the Eclipse EDC Identity Hub project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time. For example, look at the [Quarkus instance trends dashboard](https://ge.quarkus.io/scans/trends?search.relativeStartTime=P28D&search.tags=ci&search.timeZoneId=Europe%2FLjubljana) with the `ci` filter applied.
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures. You can also explore the [Quarkus instance](https://ge.quarkus.io/scans/failures?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) for example of a different OSS projects Develocity instance.
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests. Going to the [Quarkus instance](https://ge.quarkus.io/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) again, this will probably give you a better representation of the type of data available. You can also order it by flakiness, which is a good starting point when deciding which tests need fixing the most.

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. In this PR, build caching is already configured and enabled.

I ran [some tests](https://github.com/ribafish/kotlinTests/actions/runs/13501069438) about build speed improvements when caching is configured with the following results - there is additional ~20s os savings available when the project is relocated, but that would require a fix in the [EDC Gradle Plugins / AutodocDependencyInjector](https://github.com/eclipse-edc/GradlePlugins/blob/60afb05e209307376abeaf88aae947354e84e430/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java#L56). Here are the best case savings:

| Invocation | Build time without cache | Build time with cache | Build time savings |
|-----------|--------------------------|-----------------------|-------------------|
| `assemble` | 3m 40s | 15.977s | 3m 24s (92%) |
| `build` | 6m 5s | 19s | 5m 46s (94%) |
| `checkstyleMain checkstyleTest checkstyleTestFixtures` | 3m 11.771s | 6.337s | 3m 5.434s (96%) |
| `javadoc` | 3m 23.233s | 6.061s | 3m 17.172s (97%) |
| `test` | 4m 35.221s | 8.013s | 4m 27.208s (97% |
| `compileJava compileTestJava test -DincludeTags=ComponentTest,ApiTest,EndToEndTest` | 6m 22.417s | 8.290s | 6m 14.127s (98%) |
| `compileJava compileTestJava test -DincludeTags=PostgresqlIntegrationTest` | 5m 36.637s | 8.375s | 5m 28.262s (97%) |

As explained in the [Eclipse Develocity documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration), you can start publishing scans locally if you run the `./gradlew provisionDevelocityAccessKey` task, which will take you to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), where you can log in with your eclipse account and confirm access key generation. All the subsequent builds will be published.

Caching can be tested without setting up the Develocity credentials - simply run 2 or more builds (the first one will fill the local cache, next ones can use it).

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**

